### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]


### PR DESCRIPTION
Potential fix for [https://github.com/mauricekastelijn/tetris-game/security/code-scanning/4](https://github.com/mauricekastelijn/tetris-game/security/code-scanning/4)

In general, to fix this class of problem, you explicitly declare a `permissions:` block for the workflow (or individual jobs) that grants only the scopes actually needed. For this CI pipeline, all jobs only read the repository code and upload artifacts; none requires write access to repository contents, issues, or pull requests. The minimal reasonable permission is `contents: read`, applied at the workflow root so it covers all jobs (`test`, `lint`, `build`, and `security`) unless a job later overrides it.

Concretely, in `.github/workflows/ci.yml`, add a `permissions:` section near the top of the file, between `name: CI` and `on:` (or just after `on:` if you prefer, but placing it directly under the name is common). Set `contents: read` within that block. No other changes, imports, or additional configuration are required, and you do not need per‑job `permissions:` sections unless some job later needs more granular or write scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
